### PR TITLE
Fix: Bulder API /eth/v1/builder/status sync issue

### DIFF
--- a/modules/block-aggregator/backend.go
+++ b/modules/block-aggregator/backend.go
@@ -24,6 +24,8 @@ func (b *BlockAggregatorService) checkBlockSources() error {
 
 	handleStatusCheck := func(module string) {
 
+		defer wg.Done()
+
 		err := b.coreClient.Call(nil, module+"_status", false, nil)
 		mu.Lock()
 		defer mu.Unlock()


### PR DESCRIPTION
Fix: Builder API /eth/v1/builder/status sync issue

Nimbus issues GET /eth/v1/builder/status via the builder API before registerValidator is called, but there is a sync issue in mev-plus/modules/block-aggregator/backend.go that prevents the status call from completing.